### PR TITLE
Replace mentions of swapi.co with swapi.dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ output/*/index.html
 docs/_build
 
 *venv*
+
+# IDEs
+.idea
+.code

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ swapi-python
         :target: https://pypi.python.org/pypi/swapi
 
 
-A Python helper library for swapi.co - the Star Wars API
+A Python helper library for swapi.dev - the Star Wars API
 
 NOTE: Tests will run against hosted API as opposed to data from github repo
 
@@ -42,7 +42,7 @@ All resources are accessible through the top-level ``get_resource()`` methods::
 Methods
 =======
 
-These are the top-level methods you can use to get resources from swapi.co. To learn more about the models and objects that are returned, see the ``models`` page.
+These are the top-level methods you can use to get resources from swapi.dev. To learn more about the models and objects that are returned, see the ``models`` page.
 
 get_person(id)
 ------------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -108,7 +108,7 @@ A novelty method that prints out each line of the opening crawl with a 0.5 secon
 Multiple Collection Model
 =========================
 
-When you query swapi.co for multiple resources of the same type, they will be returned as a ``ResourceQuerySet``, which is a collection of those resources that you requested. For example, to get the ``Starship`` resources linked to a person, you can do the following::
+When you query swapi.dev for multiple resources of the same type, they will be returned as a ``ResourceQuerySet``, which is a collection of those resources that you requested. For example, to get the ``Starship`` resources linked to a person, you can do the following::
 
     luke = swapi.get_person(1)
     starships = luke.get_starships()

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,12 @@ except ImportError:
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
-requirements = [
-    'requests==2.5.0', 'six==1.8.0', 'ujson==1.33'
-]
+requirements = ['requests', 'six', 'ujson']
 
 setup(
     name='swapi',
-    version='0.1.3',
-    description='A Python helper library for swapi.co - the Star Wars API',
+    version='0.2.0',
+    description='A Python helper library for swapi.dev - the Star Wars API',
     long_description=readme + '\n\n' + history,
     author='Paul Hallett',
     author_email='paulandrewhallett@gmail.com',

--- a/swapi/settings.py
+++ b/swapi/settings.py
@@ -9,7 +9,7 @@ DEBUG = bool(os.environ.get(('DEBUG'), False))
 if DEBUG:
     BASE_URL = 'http://localhost:8000/api'
 else:
-    BASE_URL = 'http://swapi.co/api'
+    BASE_URL = 'http://swapi.dev/api'
 
 PEOPLE = 'people'
 PLANETS = 'planets'


### PR DESCRIPTION
Library was not functioning with `swapi.settings.BASE_URL` set to `swapi.co/api`.

This PR 
- replaces all mentions of `swapi.co` with `swapi.dev`
- unpins the version requirements for installation
- bumps the version to `0.2.0`