### PR TITLE
Change broken API to the working one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ swapi-python
         :target: https://pypi.python.org/pypi/swapi
 
 
-A Python helper library for swapi.co - the Star Wars API
+A Python helper library for swapi.dev - the Star Wars API
 
 NOTE: Tests will run against hosted API as opposed to data from github repo
 
@@ -42,7 +42,7 @@ All resources are accessible through the top-level ``get_resource()`` methods::
 Methods
 =======
 
-These are the top-level methods you can use to get resources from swapi.co. To learn more about the models and objects that are returned, see the ``models`` page.
+These are the top-level methods you can use to get resources from swapi.dev. To learn more about the models and objects that are returned, see the ``models`` page.
 
 get_person(id)
 ------------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -108,7 +108,7 @@ A novelty method that prints out each line of the opening crawl with a 0.5 secon
 Multiple Collection Model
 =========================
 
-When you query swapi.co for multiple resources of the same type, they will be returned as a ``ResourceQuerySet``, which is a collection of those resources that you requested. For example, to get the ``Starship`` resources linked to a person, you can do the following::
+When you query swapi.dev for multiple resources of the same type, they will be returned as a ``ResourceQuerySet``, which is a collection of those resources that you requested. For example, to get the ``Starship`` resources linked to a person, you can do the following::
 
     luke = swapi.get_person(1)
     starships = luke.get_starships()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ pep8==1.5.7
 pyflakes==0.8.1
 requests==2.5.0
 six==1.8.0
-ujson==1.33
+ujson==4.0.2
 wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 requirements = [
-    'requests==2.5.0', 'six==1.8.0', 'ujson==1.33'
+    'requests==2.5.0', 'six==1.8.0', 'ujson==4.0.2'
 ]
 
 setup(

--- a/swapi/settings.py
+++ b/swapi/settings.py
@@ -9,7 +9,7 @@ DEBUG = bool(os.environ.get(('DEBUG'), False))
 if DEBUG:
     BASE_URL = 'http://localhost:8000/api'
 else:
-    BASE_URL = 'http://swapi.co/api'
+    BASE_URL = 'http://swapi.dev/api'
 
 PEOPLE = 'people'
 PLANETS = 'planets'


### PR DESCRIPTION
I have created this pull request because the pull request #10, created by @bibajz.  This PR has not been active since since August of last year but all the credit still goes to him.
What I changed:
1) All mentions of swapi.co has been changed to svapi.dev, the working Star Wars API
2) Since I was having a build issue on ujson version 1.3 on python3.9 I have changed the ujson version to the latest version,
    I have tested the change in ubuntu 20.04 and OSX Big Sur and the package and all the models work perfectly with this version 
    of ujson. 
The only thing that needs to be done now is to change the mentions of swapi.co to swapi.dev in the documentation.

I believe this package useful for Star Wars fans like me and many others and should be kept maintained, so if you are no longer interested in maintaining the package I would be more than willing to take over.