### PR TITLE
Update swapi URL (.co -> .dev)

### DIFF
--- a/swapi/settings.py
+++ b/swapi/settings.py
@@ -9,7 +9,7 @@ DEBUG = bool(os.environ.get(('DEBUG'), False))
 if DEBUG:
     BASE_URL = 'http://localhost:8000/api'
 else:
-    BASE_URL = 'http://swapi.co/api'
+    BASE_URL = 'http://swapi.dev/api'
 
 PEOPLE = 'people'
 PLANETS = 'planets'


### PR DESCRIPTION
The base API URL ending in .co was deprecated. The new url ends in .dev. This PR updates that in settings.py